### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage example:
 
 ```yaml
 module "fyde-access-proxy" {
-  source = "git::git@github.com:fyde/terraform-modules.git//modules/aws-asg?ref=v1.0.0"
+  source = "git::git@github.com:fyde/terraform-modules.git//modules/aws-asg?ref=v1.1.0"
 
   # Fyde Access Proxy
   fyde_access_proxy_public_port = 443

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -32,7 +32,7 @@
 | launch\_cfg\_associate\_public\_ip\_address | Associate a public ip address with an instance in a VPC | `bool` | `false` | no |
 | launch\_cfg\_instance\_type | The type of instance to use (t2.micro, t2.small, t2.medium, etc) | `string` | `"t2.small"` | no |
 | launch\_cfg\_key\_pair\_name | The name of the key pair to use | `string` | n/a | yes |
-| module\_version | Terraform module version | `string` | `"v1.0.0"` | no |
+| module\_version | Terraform module version | `string` | `"v1.1.0"` | no |
 | nlb\_enable\_cross\_zone\_load\_balancing | Configure cross zone load balancing for the NLB | `bool` | `false` | no |
 | nlb\_subnets | A list of public subnet IDs to attach to the LB. Use Public Subnets only | `list(string)` | n/a | yes |
 | redis\_subnets | A list of subnet IDs to to use for the redis instances.<br>  At least two subnets on different Availability Zones must be provided | `list` | `[]` | no |

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -24,6 +24,8 @@
 | asg\_notification\_arn\_topic | Optional ARN topic to get Auto Scaling Group events | `string` | `""` | no |
 | asg\_subnets | A list of subnet IDs to launch resources in.<br>  Use Private Subnets with NAT Gateway configured or Public Subnets | `list` | n/a | yes |
 | aws\_region | AWS Region | `string` | n/a | yes |
+| cloudWatch\_logs\_retention\_in\_days | Days to keep CloudWatch logs (Possible values are:<br>    1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.<br>    0 = never delete.) | `number` | `7` | no |
+| cloudwatch\_logs\_enabled | Set to true to send '/var/log/message' logs to CloudWatch | `bool` | `true` | no |
 | fyde\_access\_proxy\_public\_port | Public port for this proxy (must match the value configured in the console for this proxy) | `number` | `443` | no |
 | fyde\_access\_proxy\_token | Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation) | `any` | n/a | yes |
 | launch\_cfg\_associate\_public\_ip\_address | Associate a public ip address with an instance in a VPC | `bool` | `false` | no |

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -21,7 +21,7 @@
 | asg\_max\_size | The minimum size of the auto scaling group | `number` | `3` | no |
 | asg\_min\_size | The maximum size of the auto scaling group | `number` | `3` | no |
 | asg\_notification\_arn\_topic | Optional ARN topic to get Auto Scaling Group events | `string` | `""` | no |
-| asg\_subnets | A list of subnet IDs to launch resources in. Use Private Subnets with NAT Gateway configured or Public Subnets | `list` | n/a | yes |
+| asg\_subnets | A list of subnet IDs to launch resources in.<br>  Use Private Subnets with NAT Gateway configured or Public Subnets | `list` | n/a | yes |
 | aws\_region | AWS Region | `string` | n/a | yes |
 | fyde\_access\_proxy\_public\_port | Public port for this proxy (must match the value configured in the console for this proxy) | `number` | `443` | no |
 | fyde\_access\_proxy\_token | Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation) | `any` | n/a | yes |

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -35,6 +35,7 @@
 | module\_version | Terraform module version | `string` | `"v1.0.0"` | no |
 | nlb\_enable\_cross\_zone\_load\_balancing | Configure cross zone load balancing for the NLB | `bool` | `false` | no |
 | nlb\_subnets | A list of public subnet IDs to attach to the LB. Use Public Subnets only | `list(string)` | n/a | yes |
+| redis\_subnets | A list of subnet IDs to to use for the redis instances.<br>  At least two subnets on different Availability Zones must be provided | `list` | `[]` | no |
 
 ## Outputs
 

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -17,6 +17,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| asg\_ami | Defaults to 'fyde' to use the AMI maintained and secured by Fyde.<br>  Suported types are CentOS or AWS Linux based" | `string` | `"fyde"` | no |
 | asg\_desired\_capacity | The number of Amazon EC2 instances that should be running in the auto scaling group | `number` | `3` | no |
 | asg\_max\_size | The minimum size of the auto scaling group | `number` | `3` | no |
 | asg\_min\_size | The maximum size of the auto scaling group | `number` | `3` | no |

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13 |
 | aws | ~> 2 |
 | template | ~> 2 |
 

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -28,6 +28,7 @@
 | cloudwatch\_logs\_enabled | Set to true to send '/var/log/message' logs to CloudWatch | `bool` | `true` | no |
 | fyde\_access\_proxy\_public\_port | Public port for this proxy (must match the value configured in the console for this proxy) | `number` | `443` | no |
 | fyde\_access\_proxy\_token | Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation) | `any` | n/a | yes |
+| fyde\_proxy\_level | Set the Fyde Proxy orchestrator log level | `string` | `"info"` | no |
 | launch\_cfg\_associate\_public\_ip\_address | Associate a public ip address with an instance in a VPC | `bool` | `false` | no |
 | launch\_cfg\_instance\_type | The type of instance to use (t2.micro, t2.small, t2.medium, etc) | `string` | `"t2.small"` | no |
 | launch\_cfg\_key\_pair\_name | The name of the key pair to use | `string` | n/a | yes |

--- a/modules/aws-asg/locals.tf
+++ b/modules/aws-asg/locals.tf
@@ -4,6 +4,8 @@
 
 locals {
 
+  redis_enabled = var.asg_desired_capacity > 1 ? true : false
+
   common_tags_map = {
     application      = "fyde-access-proxy"
     "module_version" = var.module_version

--- a/modules/aws-asg/main.tf
+++ b/modules/aws-asg/main.tf
@@ -3,8 +3,9 @@
 #
 
 resource "aws_secretsmanager_secret" "token" {
-  name        = "fyde_enrollment_token"
-  description = "Fyde Access Proxy Enrollment Token"
+  name                    = "fyde_enrollment_token"
+  description             = "Fyde Access Proxy Enrollment Token"
+  recovery_window_in_days = 0
 
   tags = local.common_tags_map
 }

--- a/modules/aws-asg/main.tf
+++ b/modules/aws-asg/main.tf
@@ -54,7 +54,7 @@ resource "aws_lb_listener" "nlb_listener" {
 }
 
 resource "aws_lb_target_group" "nlb_target_group" {
-  deregistration_delay = 300
+  deregistration_delay = 60
   name_prefix          = "fyde-"
   port                 = var.fyde_access_proxy_public_port
   protocol             = "TCP"
@@ -169,7 +169,7 @@ resource "aws_autoscaling_group" "asg" {
   max_size                  = var.asg_max_size
   metrics_granularity       = "1Minute"
   min_size                  = var.asg_min_size
-  name_prefix               = "fyde-access-proxy-"
+  name                      = aws_launch_configuration.launch_config.name
   target_group_arns         = [aws_lb_target_group.nlb_target_group.arn]
   termination_policies      = ["OldestInstance"]
   vpc_zone_identifier       = var.asg_subnets

--- a/modules/aws-asg/main.tf
+++ b/modules/aws-asg/main.tf
@@ -168,6 +168,8 @@ resource "aws_autoscaling_group" "asg" {
 #
 
 data "aws_ami" "fyde_access_proxy" {
+  count = var.asg_ami == "fyde" ? 1 : 0
+
   most_recent = true
 
   filter {
@@ -188,10 +190,9 @@ data "aws_ami" "fyde_access_proxy" {
 #
 
 resource "aws_launch_configuration" "launch_config" {
-
   associate_public_ip_address = var.launch_cfg_associate_public_ip_address
   iam_instance_profile        = aws_iam_instance_profile.profile.id
-  image_id                    = data.aws_ami.fyde_access_proxy.id
+  image_id                    = coalesce(data.aws_ami.fyde_access_proxy[0].id, var.asg_ami)
   instance_type               = var.launch_cfg_instance_type
   key_name                    = var.launch_cfg_key_pair_name
   name_prefix                 = "fyde-access-proxy-"

--- a/modules/aws-asg/main.tf
+++ b/modules/aws-asg/main.tf
@@ -222,7 +222,8 @@ resource "aws_launch_configuration" "launch_config" {
 #
 
 resource "aws_autoscaling_notification" "notification" {
-  count = length(var.asg_notification_arn_topic) > 0 ? 1 : 0
+  count = var.asg_notification_arn_topic == "" ? 0 : 1
+
   group_names = [
     aws_autoscaling_group.asg.name
   ]

--- a/modules/aws-asg/main.tf
+++ b/modules/aws-asg/main.tf
@@ -209,7 +209,8 @@ resource "aws_launch_configuration" "launch_config" {
   %{~endif~}
   curl -sL "https://url.fyde.me/install-fyde-proxy-linux" | bash -s -- \
     -u \
-    -p "${var.fyde_access_proxy_public_port}"
+    -p "${var.fyde_access_proxy_public_port}" \
+    -l "${var.fyde_proxy_level}"
   EOT
 
   root_block_device {

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -7,10 +7,26 @@ variable "fyde_access_proxy_public_port" {
   description = "Public port for this proxy (must match the value configured in the console for this proxy)"
   type        = number
   default     = 443
+
+  validation {
+    condition = (
+      var.fyde_access_proxy_public_port >= 1 &&
+      var.fyde_access_proxy_public_port <= 65535
+    )
+    error_message = "Public port needs to be >= 1 and <= 65535."
+  }
 }
 
 variable "fyde_access_proxy_token" {
   description = "Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation)"
+
+  validation {
+    condition = can(
+      regex("^https://.+[.]fyde[.]com/proxies.+proxy_auth_token.+$",
+      var.fyde_access_proxy_token)
+    )
+    error_message = "Provided Fyde Access Proxy Token doesn't match the expected format."
+  }
 }
 
 variable "module_version" {

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -43,7 +43,7 @@ variable "fyde_proxy_level" {
 variable "module_version" {
   description = "Terraform module version"
   type        = string
-  default     = "v1.0.0"
+  default     = "v1.1.0"
 }
 
 #

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -129,3 +129,23 @@ variable "launch_cfg_key_pair_name" {
   description = "The name of the key pair to use"
   type        = string
 }
+
+#
+# CloudWatch
+#
+
+variable "cloudwatch_logs_enabled" {
+  description = "Set to true to send '/var/log/message' logs to CloudWatch"
+  type        = bool
+  default     = true
+}
+
+variable "cloudWatch_logs_retention_in_days" {
+  description = <<EOF
+    Days to keep CloudWatch logs (Possible values are:
+    1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+    0 = never delete.)
+  EOF
+  type        = number
+  default     = 7
+}

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -29,6 +29,17 @@ variable "fyde_access_proxy_token" {
   }
 }
 
+variable "fyde_proxy_level" {
+  description = "Set the Fyde Proxy orchestrator log level"
+  type        = string
+  default     = "info"
+
+  validation {
+    condition     = can(regex("^(info|warning|error|critical|debug)$", var.fyde_proxy_level))
+    error_message = "AllowedValues: info, warning, error, critical or debug."
+  }
+}
+
 variable "module_version" {
   description = "Terraform module version"
   type        = string

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -81,7 +81,10 @@ variable "asg_max_size" {
 }
 
 variable "asg_subnets" {
-  description = "A list of subnet IDs to launch resources in. Use Private Subnets with NAT Gateway configured or Public Subnets"
+  description = <<EOF
+  A list of subnet IDs to launch resources in.
+  Use Private Subnets with NAT Gateway configured or Public Subnets
+  EOF
   type        = list
 }
 
@@ -108,6 +111,6 @@ variable "launch_cfg_instance_type" {
 }
 
 variable "launch_cfg_key_pair_name" {
-  type        = string
   description = "The name of the key pair to use"
+  type        = string
 }

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -160,3 +160,16 @@ variable "cloudWatch_logs_retention_in_days" {
   type        = number
   default     = 7
 }
+
+#
+# Redis
+#
+
+variable "redis_subnets" {
+  description = <<EOF
+  A list of subnet IDs to to use for the redis instances.
+  At least two subnets on different Availability Zones must be provided
+  EOF
+  type        = list
+  default     = []
+}

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -62,6 +62,21 @@ variable "nlb_subnets" {
 #
 # Auto Scaling Group
 #
+
+variable "asg_ami" {
+  description = <<EOF
+  Defaults to 'fyde' to use the AMI maintained and secured by Fyde.
+  Suported types are CentOS or AWS Linux based"
+  EOF
+  type        = string
+  default     = "fyde"
+
+  validation {
+    condition     = can(regex("^(fyde|ami-.+)$", var.asg_ami))
+    error_message = "AllowedValues: fyde or AMI id starting with 'ami-'."
+  }
+}
+
 variable "asg_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the auto scaling group"
   type        = number

--- a/modules/aws-asg/versions.tf
+++ b/modules/aws-asg/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13"
 
   required_providers {
     aws      = "~> 2"


### PR DESCRIPTION
# What

- Require terraform 0.13 to allow validations
- Update README and misc logic
- Allow using custom AMI
- Add CloudWatch logs configuration
- Add Fyde Access Proxy log level configuration
- Prevent lingering token after module removal
- Create redis elasticache when instance count is more than 1
- Recycle instances on launch configuration change
- Update to v1.1.0

# Tests

- Deployed multiple times with different configurations